### PR TITLE
update to use terrapin instead of cocaine dependency

### DIFF
--- a/lib/paperclip-mozjpeg.rb
+++ b/lib/paperclip-mozjpeg.rb
@@ -43,9 +43,9 @@ module Paperclip
         parameters = parameters.flatten.compact.join(" ").strip.squeeze(" ")
 
         success = cjpeg(parameters, :source => "#{File.expand_path(src.path)}", :dest => File.expand_path(dst.path))
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         raise Paperclip::Error, "There was an error processing the file for #{@basename}" if @whiny
-      rescue Cocaine::CommandNotFoundError => e
+      rescue Terrapin::CommandNotFoundError => e
         raise Paperclip::Errors::CommandNotFoundError.new("Could not run the `cjpeg` command. Please install MozJPEG.")
       end
 


### PR DESCRIPTION
## Context
The maintainers of Paperclip have deprecated the Cocaine commandline helper as of Paperclip [release 5.3.0](https://github.com/thoughtbot/paperclip/pull/2553) and have renamed it Terrapin. 

## Solution
This PR updates the gem to use Terrapin instead of Cocaine. Since this is a breaking change for older versions of this gem, I recommend cutting a major release. 