### PR TITLE
Be dependant to kt-paperclip instead of paperclip

### DIFF
--- a/paperclip-mozjpeg.gemspec
+++ b/paperclip-mozjpeg.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "minitest", "~> 5.4.2"
 
-  spec.add_dependency "paperclip"
+  spec.add_dependency "kt-paperclip"
 
 end


### PR DESCRIPTION
kt-paperclip is a supported fork of paperclip, it is compatible with ruby 3.0