### PR TITLE
Update paperclip-mozjpeg.gemspec

### DIFF
--- a/paperclip-mozjpeg.gemspec
+++ b/paperclip-mozjpeg.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "minitest", "~> 5.4.2"
 
-  spec.add_dependency "paperclip"
+  spec.add_dependency "kt-paperclip"
 
 end


### PR DESCRIPTION
This commit use kt-paperclip as a dependency as it is now the replacement of paperclip (which is not maintained anymore) In use in production since many month without any issue